### PR TITLE
Import Models module in Views.lua to fix 3.148 Lua errors

### DIFF
--- a/addon-adr/ActionDurationReminder/src/Views.lua
+++ b/addon-adr/ActionDurationReminder/src/Views.lua
@@ -3,6 +3,7 @@
 --========================================
 local addon = ActionDurationReminder -- Addon#M
 local settings = addon.load("Settings#M")
+local models = addon.load("Models#M")
 local l = {} -- #L
 local m = {l=l} -- #M
 local mWidget = {} -- #Widget


### PR DESCRIPTION
## Summary

- v3.148 introduced `models.isValidStackEffect()` and started calling it from `Views.lua:461` and `:466`, but `Views.lua` never imported the `Models` module. Every redraw of a widget with a `stackEffect` (or a `stageInfo`) throws `attempt to index a nil value`.
- Fix: add `local models = addon.load("Models#M")` next to the existing `settings` import. Manifest already loads `src/Models.lua` before `src/Views.lua`, so the lookup is safe.

## Why this explains the reported symptoms

Reproduces the ESOUI v3.148 bug report:

- **"Firekeeper Lua error at Views.lua:461"** — stack path (`stackCount > 0 and not stackEffectHasStageInfo and models.isValidStackEffect(...)`).
- **"Incinerate Lua error at Views.lua:466"** — stage path (`stageInfo and models.isValidStackEffect(...)`).
- **"Only the last-cast DK skill timer shows, other class timers lost"** — the throw aborts `Bar.l.onCoreUpdate`'s `for slotNum = 3,8 do` loop, so every slot after the offending one (plus the shifted/appended widget cleanup in steps 2-4) never updates on that tick.
- **"Firekeeper sticks at red 0.0 until another DK skill is cast"** — the "remain <= 0" cleanup block at `Views.lua:513-525` runs *after* the crash point and never executes, and `Core.l.refineActions` skips removal while `stackCount > 0`, so the action plus stuck widget remain until a new action overwrites the slot.

ESO throttles repeat Lua errors to one dialog per session, which is why the error "only triggers once, then doesn't come back until /reloadui" even though it fires every 100 ms.

## Test plan

- [ ] `/reloadui` with the patch applied; cast Firekeeper - no Lua error; widget counts down and clears normally.
- [ ] Cast a skill with `stageInfo` (e.g. Incinerate) - no Lua error at line 466.
- [ ] Multi-skill rotation (arcanist + DK backbar combo): all timers remain visible; no slot dropped after a Firekeeper cast.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>